### PR TITLE
Fixes to the existing setup

### DIFF
--- a/autonomio-full/Dockerfile
+++ b/autonomio-full/Dockerfile
@@ -4,6 +4,7 @@ CMD ["/sbin/my_init"]
 WORKDIR /var/www/html/
 ADD . /var/www/html/
 
+RUN mkdir -p /var/www/html/data_temp
 RUN apt-get update
 RUN apt-get -y install git
 RUN apt-get -y install python-pip

--- a/autonomio-full/Dockerfile
+++ b/autonomio-full/Dockerfile
@@ -18,6 +18,7 @@ RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 RUN pip install jinja2
 RUN pip install jupyter
+pip install git+https://github.com/autonomio/core-module.git
 
 RUN python -m spacy download en
 
@@ -41,6 +42,6 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/
 RUN chmod +x /usr/bin/tini
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
-CMD ["jupyter", "notebook", "--port=8123", "--no-browser", "--ip=0.0.0.0", "--NotebookApp.token=''", "--NotebookApp.disable_check_xsrf=True", "--allow-root", "--NotebookApp.base_url=./examples"]
+CMD ["jupyter", "notebook", "--port=8123", "--no-browser", "--ip=0.0.0.0", "--NotebookApp.token=''", "--NotebookApp.disable_check_xsrf=True", "--allow-root", "--NotebookApp.base_url=./data_temp"]
 
 CMD ["service", "apache2", "start"]

--- a/autonomio-full/Dockerfile
+++ b/autonomio-full/Dockerfile
@@ -22,8 +22,9 @@ RUN python -m spacy download en
 
 RUN chown www-data:www-data -R /var/www/html/
 RUN service apache2 restart
+RUN update-rc.d apache2 defaults
 
-EXPOSE 80
+EXPOSE 80 8123
 ENV NAME World
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -32,4 +33,13 @@ RUN adduser --disabled-password --gecos "" autonomio
 RUN su autonomio
 RUN cd
 
-RUN cp -r /var/www/html/autonomio /home/autonomio/autonomio
+# Add Tini. Tini operates as a process subreaper for jupyter. This prevents
+# kernel crashes.
+ENV TINI_VERSION v0.6.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN chmod +x /usr/bin/tini
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+CMD ["jupyter", "notebook", "--port=8123", "--no-browser", "--ip=0.0.0.0", "--NotebookApp.token=''", "--NotebookApp.disable_check_xsrf=True", "--allow-root", "--NotebookApp.base_url=./examples"]
+
+CMD ["service", "apache2", "start"]


### PR DESCRIPTION
1. Enable apache2 service to start on every reboot.
2. Expose ports 4140 and 4141 by default in the dockerfile
3. Put in the fixes recommended by jupyter documentation. Also, will create a new folder inside autonomio-full (will call it data_temp) and make it the jupyter root folder.
4. Deprecate the container script. Basically, everything should run without the container utility. 